### PR TITLE
G3P-7233: Update LWIP FileList

### DIFF
--- a/src/Filelists.cmake
+++ b/src/Filelists.cmake
@@ -8,10 +8,6 @@
 # The intention is to provide greater flexibility to users to
 # create their own targets using the *_SRCS variables.
 
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0")
-    include_guard(GLOBAL)
-endif()
-
 set(LWIP_VERSION_MAJOR    "2")
 set(LWIP_VERSION_MINOR    "2")
 set(LWIP_VERSION_REVISION "1")
@@ -57,6 +53,7 @@ set(lwipcore_SRCS
     ${LWIP_DIR}/src/core/timeouts.c
     ${LWIP_DIR}/src/core/udp.c
 )
+
 set(lwipcore4_SRCS
     ${LWIP_DIR}/src/core/ipv4/acd.c
     ${LWIP_DIR}/src/core/ipv4/autoip.c
@@ -251,6 +248,10 @@ set(lwipallapps_SRCS
     ${lwiptftp_SRCS}
     ${lwipmqtt_SRCS}
 )
+
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.10.0")
+    include_guard(GLOBAL)
+endif()
 
 # Generate lwip/init.h (version info)
 configure_file(${LWIP_DIR}/src/include/lwip/init.h.cmake.in ${LWIP_DIR}/src/include/lwip/init.h)


### PR DESCRIPTION
These updates are necessary for generating lwip as an interface library.

As we move towards a static library, we can revert these changes to be more like the upstream `master`.

For generating multiple libraries in one go, we need to set the variables in the file list multiple times per configure. This changes the location of the include guard to make sure the file lists always populate when included.