### PR TITLE
G3P-23754: close (mbox, recv_avail) race in netconn recv callbacks

### DIFF
--- a/src/api/api_msg.c
+++ b/src/api/api_msg.c
@@ -190,16 +190,30 @@ recv_raw(void *arg, struct raw_pcb *pcb, struct pbuf *p,
       buf->port = pcb->protocol;
 
       len = q->tot_len;
-      if (sys_mbox_trypost(&conn->recvmbox, buf) != ERR_OK) {
-        netbuf_delete(buf);
-        return 0;
-      } else {
+      {
+        SYS_ARCH_DECL_PROTECT(lev);
+        /* G3P-23754: Make (mbox post, recv_avail bump) atomic under SYS_ARCH_PROTECT.
+           A reader (lwip_pollscan / lwip_select) inspecting conn->recv_avail under
+           the same lock now cannot observe (mbox has buf, recv_avail == 0). The
+           old code did the post and the rcvevent bump in two separate critical
+           sections; a reader could see (mbox has buf, rcvevent == 0) in between,
+           report nothing readable, and park on the select sem until a later
+           packet nudged things. The wakeup (API_EVENT) is intentionally fired
+           OUTSIDE the protect so sys_sem_signal does not strand the woken
+           consumer on lwip_sys_mutex. */
+        SYS_ARCH_PROTECT(lev);
+        if (sys_mbox_trypost(&conn->recvmbox, buf) != ERR_OK) {
+          SYS_ARCH_UNPROTECT(lev);
+          netbuf_delete(buf);
+          return 0;
+        }
 #if LWIP_SO_RCVBUF
-        SYS_ARCH_INC(conn->recv_avail, len);
+        conn->recv_avail += (int)len;
 #endif /* LWIP_SO_RCVBUF */
-        /* Register event with callback */
-        API_EVENT(conn, NETCONN_EVT_RCVPLUS, len);
+        SYS_ARCH_UNPROTECT(lev);
       }
+      /* Register event with callback (outside the protect, see comment above). */
+      API_EVENT(conn, NETCONN_EVT_RCVPLUS, len);
     }
   }
 
@@ -270,18 +284,28 @@ recv_udp(void *arg, struct udp_pcb *pcb, struct pbuf *p,
   }
 
   len = p->tot_len;
-  err = sys_mbox_trypost(&conn->recvmbox, buf);
-  if (err != ERR_OK) {
-    netbuf_delete(buf);
-    LWIP_DEBUGF(API_MSG_DEBUG, ("recv_udp: sys_mbox_trypost failed, err=%d\n", err));
-    return;
-  } else {
+  {
+    SYS_ARCH_DECL_PROTECT(lev);
+    /* G3P-23754: Make (mbox post, recv_avail bump) atomic under SYS_ARCH_PROTECT,
+       but fire API_EVENT outside the protect. See recv_raw above for the
+       rationale -- TL;DR the consumer's pollscan reads recv_avail under the
+       same lock and so cannot observe (mbox has buf, recv_avail == 0); and the
+       wakeup must not strand the woken consumer on lwip_sys_mutex. */
+    SYS_ARCH_PROTECT(lev);
+    err = sys_mbox_trypost(&conn->recvmbox, buf);
+    if (err != ERR_OK) {
+      SYS_ARCH_UNPROTECT(lev);
+      netbuf_delete(buf);
+      LWIP_DEBUGF(API_MSG_DEBUG, ("recv_udp: sys_mbox_trypost failed, err=%d\n", err));
+      return;
+    }
 #if LWIP_SO_RCVBUF
-    SYS_ARCH_INC(conn->recv_avail, len);
+    conn->recv_avail += (int)len;
 #endif /* LWIP_SO_RCVBUF */
-    /* Register event with callback */
-    API_EVENT(conn, NETCONN_EVT_RCVPLUS, len);
+    SYS_ARCH_UNPROTECT(lev);
   }
+  /* Register event with callback (outside the protect, see comment above). */
+  API_EVENT(conn, NETCONN_EVT_RCVPLUS, len);
 }
 #endif /* LWIP_UDP */
 
@@ -331,16 +355,24 @@ recv_tcp(void *arg, struct tcp_pcb *pcb, struct pbuf *p, err_t err)
     len = 0;
   }
 
-  if (sys_mbox_trypost(&conn->recvmbox, msg) != ERR_OK) {
-    /* don't deallocate p: it is presented to us later again from tcp_fasttmr! */
-    return ERR_MEM;
-  } else {
+  {
+    SYS_ARCH_DECL_PROTECT(lev);
+    /* G3P-23754: Make (mbox post, recv_avail bump) atomic under SYS_ARCH_PROTECT,
+       but fire API_EVENT outside the protect. See recv_raw above for the
+       rationale. */
+    SYS_ARCH_PROTECT(lev);
+    if (sys_mbox_trypost(&conn->recvmbox, msg) != ERR_OK) {
+      SYS_ARCH_UNPROTECT(lev);
+      /* don't deallocate p: it is presented to us later again from tcp_fasttmr! */
+      return ERR_MEM;
+    }
 #if LWIP_SO_RCVBUF
-    SYS_ARCH_INC(conn->recv_avail, len);
+    conn->recv_avail += (int)len;
 #endif /* LWIP_SO_RCVBUF */
-    /* Register event with callback */
-    API_EVENT(conn, NETCONN_EVT_RCVPLUS, len);
+    SYS_ARCH_UNPROTECT(lev);
   }
+  /* Register event with callback (outside the protect, see comment above). */
+  API_EVENT(conn, NETCONN_EVT_RCVPLUS, len);
 
   return ERR_OK;
 }

--- a/src/api/sockets.c
+++ b/src/api/sockets.c
@@ -1901,11 +1901,24 @@ lwip_selscan(int maxfdp1, fd_set *readset_in, fd_set *writeset_in, fd_set *excep
       s16_t rcvevent = sock->rcvevent;
       u16_t sendevent = sock->sendevent;
       u16_t errevent = sock->errevent;
+#if LWIP_SO_RCVBUF
+      /* G3P-23754: also gate POLLIN on conn->recv_avail. recv_udp/raw/tcp
+         atomically bumps recv_avail in the same SYS_ARCH_PROTECT critical
+         section as the mbox post, so observing recv_avail > 0 here is a
+         race-free witness that data is queued -- even if rcvevent has not
+         been incremented yet by the (later, separate) API_EVENT call. */
+      int recv_avail = (sock->conn != NULL) ? sock->conn->recv_avail : 0;
+#endif /* LWIP_SO_RCVBUF */
       SYS_ARCH_UNPROTECT(lev);
 
       /* ... then examine it: */
       /* See if netconn of this socket is ready for read */
+#if LWIP_SO_RCVBUF
+      if (readset_in && FD_ISSET(i, readset_in) &&
+          ((lastdata != NULL) || (rcvevent > 0) || (recv_avail > 0))) {
+#else
       if (readset_in && FD_ISSET(i, readset_in) && ((lastdata != NULL) || (rcvevent > 0))) {
+#endif /* LWIP_SO_RCVBUF */
         FD_SET(i, &lreadset);
         LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_selscan: fd=%d ready for reading\n", i));
         nready++;
@@ -2263,6 +2276,14 @@ lwip_pollscan(struct pollfd *fds, nfds_t nfds, enum lwip_pollscan_opts opts)
         s16_t rcvevent = sock->rcvevent;
         u16_t sendevent = sock->sendevent;
         u16_t errevent = sock->errevent;
+#if LWIP_SO_RCVBUF
+        /* G3P-23754: also gate POLLIN on conn->recv_avail. recv_udp/raw/tcp
+           atomically bumps recv_avail in the same SYS_ARCH_PROTECT critical
+           section as the mbox post, so observing recv_avail > 0 here is a
+           race-free witness that data is queued -- even if rcvevent has not
+           been incremented yet by the (later, separate) API_EVENT call. */
+        int recv_avail = (sock->conn != NULL) ? sock->conn->recv_avail : 0;
+#endif /* LWIP_SO_RCVBUF */
 
         if ((opts & LWIP_POLLSCAN_INC_WAIT) != 0) {
           sock->select_waiting++;
@@ -2286,7 +2307,12 @@ lwip_pollscan(struct pollfd *fds, nfds_t nfds, enum lwip_pollscan_opts opts)
 
         /* ... then examine it: */
         /* See if netconn of this socket is ready for read */
+#if LWIP_SO_RCVBUF
+        if ((fds[fdi].events & POLLIN) != 0 &&
+            ((lastdata != NULL) || (rcvevent > 0) || (recv_avail > 0))) {
+#else
         if ((fds[fdi].events & POLLIN) != 0 && ((lastdata != NULL) || (rcvevent > 0))) {
+#endif /* LWIP_SO_RCVBUF */
           fds[fdi].revents |= POLLIN;
           LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_pollscan: fd=%d ready for reading\n", fds[fdi].fd));
         }


### PR DESCRIPTION
api_msg.c's three netconn input callbacks (recv_raw, recv_udp, recv_tcp) posted to conn->recvmbox and then fired
API_EVENT(NETCONN_EVT_RCVPLUS) in a separate critical section. A reader inspecting socket state under SYS_ARCH_PROTECT between those two points could see rcvevent == 0 while the recvmbox already held the message, causing a consumer doing lwip_pollscan to sleep on the select semaphore and miss queued data. Under a sustained UDP flood this manifested as "UDP RX stops after flooding" / "first request silent, next request returns both responses."

Fix:
  * SYS_ARCH_PROTECT now wraps sys_mbox_trypost together with the conn->recv_avail bump, so (mbox, recv_avail) is committed atomically.
  * API_EVENT(NETCONN_EVT_RCVPLUS) fires AFTER SYS_ARCH_UNPROTECT, so sys_sem_signal wakes the broker with no lwip_sys_mutex held by the producer -- avoiding the priority-inversion stall where the broker's lwip_pollscan blocked on the mutex held by the higher-priority producer.
  * sockets.c (lwip_selscan + lwip_pollscan) reads recv_avail under the same SYS_ARCH_PROTECT and includes it in the POLLIN predicate, a race-free witness that data is queued before the later API_EVENT runs.

Applied to all three netconn input callbacks for symmetry; the UDP path is the one that motivated this.